### PR TITLE
Fix admin TypeScript build errors by removing unused icon imports

### DIFF
--- a/admin/src/pages/CreateProjectPage.tsx
+++ b/admin/src/pages/CreateProjectPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Upload, Check, AlertCircle, X, Image as ImageIcon, Sparkles, Send } from 'lucide-react';
+import { ArrowLeft, Upload, AlertCircle, X, Image as ImageIcon, Sparkles, Send } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const CreateProjectPage = () => {

--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { Trash2, ExternalLink, Github, Plus, Layers, AlertCircle, Briefcase, Eye, ChevronRight } from 'lucide-react';
+import { Trash2, Github, Plus, Layers, AlertCircle, Eye, ChevronRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const DashboardPage = () => {

--- a/admin/src/pages/MailsPage.tsx
+++ b/admin/src/pages/MailsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { Trash2, Calendar, User, AtSign, Inbox, Search, Clock, MailOpen, ChevronRight } from 'lucide-react';
+import { Trash2, AtSign, Inbox, Search, Clock, MailOpen } from 'lucide-react';
 
 const MailsPage = () => {
     const [mails, setMails] = useState<any[]>([]);


### PR DESCRIPTION
### Motivation
- The admin UI production build was failing due to TypeScript `noUnusedLocals` errors caused by unused `lucide-react` icon imports in several pages.
- Restoring a clean build is required so the admin bundle can be produced and deployed.

### Description
- Removed the unused `Check` icon import from `admin/src/pages/CreateProjectPage.tsx`.
- Removed the unused `ExternalLink` and `Briefcase` icon imports from `admin/src/pages/DashboardPage.tsx`.
- Removed the unused `Calendar`, `User`, and `ChevronRight` icon imports from `admin/src/pages/MailsPage.tsx`.
- These changes eliminate TypeScript compile errors while keeping the UI behavior unchanged.

### Testing
- Ran `npm run build` in the `admin` package and the production build completed successfully and produced `dist/` assets.
- Vite emitted CSS minifier warnings related to Tailwind/DaisyUI at-rules, but the build still finished successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc5511380832788a27cbd87dab34e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused icon imports across admin pages to improve code maintenance and reduce unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->