### PR TITLE
Fix admin UI build and lint issues

### DIFF
--- a/admin/src/hooks/useAuth.tsx
+++ b/admin/src/hooks/useAuth.tsx
@@ -2,24 +2,34 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api.ts';
 
+type AuthUser = {
+    role: 'admin';
+};
+
+type LoginResult = {
+    success: boolean;
+    message?: string;
+};
+
+type ApiError = {
+    response?: {
+        data?: string;
+    };
+};
+
 export const useAuth = () => {
-    const [user, setUser] = useState<any>(null);
+    const [user, setUser] = useState<AuthUser | null>(null);
     const [loading, setLoading] = useState(true);
     const navigate = useNavigate();
 
     const checkAuth = async () => {
         try {
-            // Check if user is logged in by hitting a protected profile link or just checking localStorage
-            // For now, we'll use a simple "logged_in" flag in localStorage for UI purposes, 
-            // but the actual security is in the httpOnly cookies handled by the server.
             const status = localStorage.getItem('isLoggedIn');
             if (status === 'true') {
                 setUser({ role: 'admin' });
             } else {
                 setUser(null);
             }
-        } catch (error) {
-            setUser(null);
         } finally {
             setLoading(false);
         }
@@ -29,15 +39,20 @@ export const useAuth = () => {
         checkAuth();
     }, []);
 
-    const login = async (username: string, password: string) => {
+    const login = async (username: string, password: string): Promise<LoginResult> => {
         try {
             await api.post('/admin/login', { username, password });
             localStorage.setItem('isLoggedIn', 'true');
             setUser({ role: 'admin' });
             navigate('/');
             return { success: true };
-        } catch (error: any) {
-            return { success: false, message: error.response?.data || 'Login failed' };
+        } catch (error) {
+            const apiError = error as ApiError;
+
+            return {
+                success: false,
+                message: apiError.response?.data || 'Login failed',
+            };
         }
     };
 

--- a/admin/src/pages/CreateProjectPage.tsx
+++ b/admin/src/pages/CreateProjectPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { ArrowLeft, Upload, Check, AlertCircle, X, Image as ImageIcon, Sparkles, Send } from 'lucide-react';
+import { ArrowLeft, Upload, AlertCircle, X, Image as ImageIcon, Sparkles, Send } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 const CreateProjectPage = () => {
@@ -63,8 +63,9 @@ const CreateProjectPage = () => {
                 headers: { 'Content-Type': 'multipart/form-data' }
             });
             navigate('/dashboard');
-        } catch (error: any) {
-            setError(error.response?.data || 'Submission failed. Please check your data.');
+        } catch (error) {
+            const apiError = error as { response?: { data?: string } };
+            setError(apiError.response?.data || 'Submission failed. Please check your data.');
         } finally {
             setLoading(false);
         }

--- a/admin/src/pages/DashboardPage.tsx
+++ b/admin/src/pages/DashboardPage.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { Trash2, ExternalLink, Github, Plus, Layers, AlertCircle, Briefcase, Eye, ChevronRight } from 'lucide-react';
+import { Trash2, Github, Plus, Layers, AlertCircle, Eye, ChevronRight } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
+type Project = {
+    _id: string;
+    projectImg: string;
+    projectTitle: string;
+    projectdesc: string;
+    projectTags: string[];
+    projectLink: string;
+    projectSrcLink?: string;
+};
+
 const DashboardPage = () => {
-    const [projects, setProjects] = useState<any[]>([]);
+    const [projects, setProjects] = useState<Project[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
 
@@ -35,7 +45,7 @@ const DashboardPage = () => {
         try {
             await api.delete(`/projects/${id}/delete`);
             setProjects(projects.filter(p => p._id !== id));
-        } catch (error) {
+        } catch {
             alert('Failed to delete project');
         }
     };

--- a/admin/src/pages/LoginPage.tsx
+++ b/admin/src/pages/LoginPage.tsx
@@ -17,7 +17,7 @@ const LoginPage = () => {
         
         const result = await login(username, password);
         if (!result.success) {
-            setError(result.message);
+            setError(result.message || 'Login failed');
         }
         setIsSubmitting(false);
     };
@@ -118,10 +118,13 @@ const LoginPage = () => {
                             className="w-full bg-primary-600 hover:bg-primary-500 text-white font-bold py-4 rounded-2xl shadow-xl shadow-primary-600/20 transition-all active:scale-[0.98] disabled:opacity-70 flex items-center justify-center gap-2 group mt-8"
                         >
                             {isSubmitting ? (
-                                <span className="loading loading-spinner loading-sm"></span>
-                            ) : (
                                 <>
                                     Authenticating...
+                                    <span className="loading loading-spinner loading-sm"></span>
+                                </>
+                            ) : (
+                                <>
+                                    Sign In
                                     <LogIn size={20} className="transition-transform group-hover:translate-x-1" />
                                 </>
                             )}

--- a/admin/src/pages/MailsPage.tsx
+++ b/admin/src/pages/MailsPage.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api.ts';
 import { motion } from 'framer-motion';
-import { Trash2, Calendar, User, AtSign, Inbox, Search, Clock, MailOpen, ChevronRight } from 'lucide-react';
+import { Trash2, AtSign, Inbox, Search, Clock, MailOpen } from 'lucide-react';
+
+type MailItem = {
+    _id: string;
+    name: string;
+    email: string;
+    subject: string;
+    message: string;
+    createdAt: string;
+};
 
 const MailsPage = () => {
-    const [mails, setMails] = useState<any[]>([]);
+    const [mails, setMails] = useState<MailItem[]>([]);
     const [loading, setLoading] = useState(true);
     const [searchTerm, setSearchTerm] = useState('');
 
@@ -32,7 +41,7 @@ const MailsPage = () => {
         try {
             await api.delete(`/mail/${id}/delete_email`);
             setMails(mails.filter(m => m._id !== id));
-        } catch (error) {
+        } catch {
             alert('Operation failed.');
         }
     };


### PR DESCRIPTION
### Motivation
- The admin UI was failing TypeScript linting and had runtime UI inconsistencies due to loose `any` usage, unused imports, and inconsistent error handling, preventing a clean build and predictable login behavior.
- Tightening types and removing unused symbols improves editor feedback and ensures the admin app compiles and runs consistently in CI and local builds.

### Description
- Tightened `useAuth` typings and return shape by adding `AuthUser`, `LoginResult`, and `ApiError` types and replaced `useState<any>` with `useState<AuthUser | null>` so auth state and login errors are type-safe (`admin/src/hooks/useAuth.tsx`).
- Fixed the login CTA and error fallback so the submit button shows `Authenticating...` only while submitting and the idle state shows `Sign In`, and ensured `setError` always receives a string fallback (`admin/src/pages/LoginPage.tsx`).
- Added explicit `Project` and `MailItem` types and removed unused icon imports to eliminate untyped access and unused symbol lint errors, and simplified catch blocks that previously introduced unused `error` variables (`admin/src/pages/DashboardPage.tsx`, `admin/src/pages/MailsPage.tsx`).
- Removed an unused `Check` import and replaced loose `any`-based error handling with a typed API error fallback in the create-project form submission (`admin/src/pages/CreateProjectPage.tsx`).

### Testing
- Ran `cd admin && npm run build` and the production build completed successfully, although LightningCSS emitted warnings about Tailwind v4 at-rules such as `@theme`/`@plugin` (these are warnings only and do not block the build).
- Ran `cd admin && npm run lint` and the previous TypeScript/ESLint errors were resolved; linter now reports no blocking errors for the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc5511380832788a27cbd87dab34e)